### PR TITLE
improve the description text

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 
     <!-- Open Graph (OG) Meta Tags for Social Sharing -->
     <meta property="og:title" content="SecureCloudX - 7-Day Azure Security Challenge" />
-    <meta property="og:description" content="Learn Azure Cloud Security with the SecureCloudX challenge. Step-by-step guides, practical tasks, and expert insights." />
+    <meta property="og:description" content="Learn Cloud Security with the SecureCloudX challenge. Step-by-step guides, practical tasks, and expert insights." />
     <meta property="og:image" content="/securecloudx-preview.png" />
     <meta property="og:url" content="https://your-securecloudx-site.com" />
     <meta property="og:type" content="website" />


### PR DESCRIPTION
This pull request includes a minor change to the Open Graph meta tags in the `index.html` file. The change updates the `og:description` content to remove the specific reference to Azure, making the description more general.

Changes to Open Graph meta tags:

* [`index.html`](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L16-R16): Updated the `og:description` content to "Learn Cloud Security with the SecureCloudX challenge. Step-by-step guides, practical tasks, and expert insights."