### PR TITLE
Refactor challenge unlock logic to use centralized start date constant

### DIFF
--- a/src/constants/challengeConfig.js
+++ b/src/constants/challengeConfig.js
@@ -1,0 +1,1 @@
+export const CHALLENGE_START_DATE = new Date("2025-06-16T00:00:00Z");

--- a/src/hooks/useChallengeUnlock.js
+++ b/src/hooks/useChallengeUnlock.js
@@ -1,6 +1,8 @@
 import { useState, useEffect } from "react";
+import { CHALLENGE_START_DATE } from "../constants/challengeConfig";
 
-const CHALLENGE_START_DATE = new Date("2025-06-15T00:00:00Z");
+
+// const CHALLENGE_START_DATE = new Date("2025-06-15T00:00:00Z");
 
 const useChallengeUnlock = () => {
   const [unlockedDays, setUnlockedDays] = useState([]);
@@ -9,19 +11,17 @@ const useChallengeUnlock = () => {
     const today = new Date();
     const timeDiff = today - CHALLENGE_START_DATE;
 
-    // How many full 7-day windows have passed since challenge began
     const weeksSinceStart = Math.floor(timeDiff / (1000 * 60 * 60 * 24 * 7));
     const unlocked = [];
 
-    // Unlock all days from Day 1 up to the current week number
     for (let i = 1; i <= weeksSinceStart + 1 && i <= 7; i++) {
-      unlocked.push(i); // Day 1 to Day 7
+      unlocked.push(i);
     }
 
     setUnlockedDays(unlocked);
   }, []);
 
-  return unlockedDays; // Example: [1, 2, 3]
+  return unlockedDays;
 };
 
 export default useChallengeUnlock;

--- a/src/routes/ProtectedDayRoute.jsx
+++ b/src/routes/ProtectedDayRoute.jsx
@@ -1,12 +1,11 @@
-// src/routes/ProtectedDayRoute.jsx
 import { Navigate, useLocation } from "react-router-dom";
-
-const CHALLENGE_START_DATE = new Date("2025-06-21T00:00:00Z");
+import { CHALLENGE_START_DATE } from "../constants/challengeConfig";
 
 const isDayUnlocked = (day) => {
   const today = new Date();
   const diffInDays = Math.floor((today - CHALLENGE_START_DATE) / (1000 * 60 * 60 * 24));
-  return diffInDays >= (day - 1);
+  const unlockDay = (day - 1) * 7;
+  return diffInDays >= unlockDay;
 };
 
 const ProtectedDayRoute = ({ day, children }) => {
@@ -15,3 +14,8 @@ const ProtectedDayRoute = ({ day, children }) => {
 };
 
 export default ProtectedDayRoute;
+// This component checks if the specified day is unlocked based on the challenge start date.
+// If the day is unlocked, it renders the children components; otherwise, it redirects to the home page.
+// The `isDayUnlocked` function calculates whether the current date is past the unlock date for the specified day.
+// The `ProtectedDayRoute` component uses React Router's `Navigate` to redirect users if they try to access a locked day.
+// The `useLocation` hook is used to preserve the current location in the state, allowing users to return to their previous page after unlocking the day


### PR DESCRIPTION
This pull request refactors the handling of the `CHALLENGE_START_DATE` constant and improves the logic for unlocking challenge days across multiple files. The changes centralize the configuration of the challenge start date, simplify the unlocking logic, and enhance code readability.

### Centralization of `CHALLENGE_START_DATE`:

* [`src/constants/challengeConfig.js`](diffhunk://#diff-dff65b4adbe4ea582ef6bdd74a950c02e3864808e8f7a855ac0f008761454a41R1): Added a centralized `CHALLENGE_START_DATE` constant to reduce redundancy and improve maintainability.
* [`src/hooks/useChallengeUnlock.js`](diffhunk://#diff-45c42d71c32296301e08dd4338ecbc749c68afb5a95f5ac3779cf6ab8eb90a16R2-R5): Removed the inline definition of `CHALLENGE_START_DATE` and replaced it with an import from `challengeConfig.js`.
* [`src/routes/ProtectedDayRoute.jsx`](diffhunk://#diff-96aa25f6893f10c83a8c9289da2c854475f7d9993e1ca4b0d62ba11bbf95db70L1-R8): Replaced the local definition of `CHALLENGE_START_DATE` with an import from `challengeConfig.js`.

### Improvements to unlocking logic:

* [`src/hooks/useChallengeUnlock.js`](diffhunk://#diff-45c42d71c32296301e08dd4338ecbc749c68afb5a95f5ac3779cf6ab8eb90a16L12-R24): Simplified the logic for calculating unlocked days by removing redundant comments and ensuring the loop dynamically unlocks up to 7 days based on the elapsed weeks since the challenge start date.
* [`src/routes/ProtectedDayRoute.jsx`](diffhunk://#diff-96aa25f6893f10c83a8c9289da2c854475f7d9993e1ca4b0d62ba11bbf95db70R17-R21): Updated the `isDayUnlocked` function to calculate unlock days in 7-day intervals, making the unlocking logic more consistent with the challenge rules. Added comments to improve code clarity and explain the behavior of the `ProtectedDayRoute` component.