### PR TITLE
Update starting link in Home component to direct users to Day 0

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -188,8 +188,8 @@ const Home = () => {
 <p className="text-gray-300 text-base md:text-lg text-start">
   Ready to begin? Start with{" "}
   {unlockedDays.includes(1) ? (
-    <Link to="/day1" className="text-blue-400 font-semibold hover:underline">
-      Day 1: Identity & Access Management
+    <Link to="/start" className="text-blue-400 font-semibold hover:underline">
+      Day 0: Starting From Zero
     </Link>
   ) : (
     <span className="text-gray-500 font-semibold cursor-not-allowed" title="Day 1 is locked">


### PR DESCRIPTION
This pull request updates the `Home` page to modify the starting day link and its associated text. The change reflects a shift from "Day 1: Identity & Access Management" to "Day 0: Starting From Zero" as the initial step.

Key change:

* [`src/pages/Home.jsx`](diffhunk://#diff-3f516fbdeb9a7ec0382eddb852845968f9cdaa1cff026ac0ce8fdf1fd351cc17L191-R192): Updated the link destination from `/day1` to `/start` and changed the displayed text from "Day 1: Identity & Access Management" to "Day 0: Starting From Zero."