### PR TITLE
Update Header component: add abbreviation label for securecloudX in t…

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -2,7 +2,7 @@ const Header = () => {
   return (
     <header className="w-full bg-gray-800 p-4 text-gray-300 shadow-md flex justify-between items-center">
       <div>
-        <h1 className="text-xl font-bold">securecloudX</h1>
+        <h1 className="text-xl font-bold">securecloudX<span className="text-xs bg-gray-600 text-white px-2 py-0.5 rounded ml-2 md:hidden">SCX</span></h1>
         <p className="text-sm text-gray-400">Master cloud security. Build secure systems.</p>
       </div>
 


### PR DESCRIPTION
This pull request introduces a minor enhancement to the `Header` component in `src/components/Header.jsx`. The update adds a small badge displaying "SCX" next to the title `securecloudX`, visible only on smaller screens (`md:hidden`).

Visual improvement:

* [`src/components/Header.jsx`](diffhunk://#diff-8c468c347b974539dbc7411567675397475e1aeac509adf899831746084c1179L5-R5): Added a badge (`<span>`) next to the title `securecloudX` with styling for small screens, improving the branding for mobile users.…itle for clarity