### PR TITLE
Update challenge start date to reflect correct timezone

### DIFF
--- a/src/constants/challengeConfig.js
+++ b/src/constants/challengeConfig.js
@@ -1,1 +1,1 @@
-export const CHALLENGE_START_DATE = new Date("2025-06-21T00:00:00Z");
+export const CHALLENGE_START_DATE = new Date("2025-06-21T03:00:00+03:00");


### PR DESCRIPTION
This pull request updates a constant in the `src/constants/challengeConfig.js` file to adjust the time zone for the challenge start date.

* [`src/constants/challengeConfig.js`](diffhunk://#diff-dff65b4adbe4ea582ef6bdd74a950c02e3864808e8f7a855ac0f008761454a41L1-R1): Changed `CHALLENGE_START_DATE` to use a time zone offset of `+03:00` instead of `UTC`, reflecting the correct local start time for the challenge.