### PR TITLE
Sirronney a blog a day

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -41,6 +41,8 @@ import Pricing from "./pages/Pricing";
 import About from "./pages/AboutAuthor";
 import Story from "./pages/Story";
 import Work from "./pages/Work";
+import SafaricomCTF2025 from "./pages/SafaricomCTF2025";
+import RealIPHeistWriteup from "./pages/RealIPHeistWriteup";
 
 const App = () => {
   return (
@@ -55,6 +57,11 @@ const App = () => {
         <Route path="/about" element={<About />} />
         <Route path="/story" element={<Story />} />
         <Route path="/work" element={<Work />} />
+        <Route path="/ctf/safaricom-2025" element={<SafaricomCTF2025 />} />
+        <Route
+          path="/ctf/safaricom-2025/real-ip-heist"
+          element={<RealIPHeistWriteup />}
+        />
 
         <Route
           path="*"

--- a/src/pages/GetStartedPage.jsx
+++ b/src/pages/GetStartedPage.jsx
@@ -241,13 +241,33 @@ export default function GetStartedPage() {
                     </span>
                   </div>
                   <p className="text-gray-500 text-sm leading-relaxed mb-3">
-                    Capture The Flag competition writeups - October 6, 2025
+                    Safaricom Capture The Flag competition - October 4-6, 2025.
                   </p>
-                  <div className="text-xs text-cyan-400 font-mono mb-2">
-                    cd /ctf/safaricom2025 && ls writeups/
+                  <div className="flex flex-wrap gap-2 mb-3">
+                    <span className="px-2 py-1 bg-gray-700 text-cyan-400 text-xs font-mono border border-gray-600">
+                      web-exploitation
+                    </span>
+                    <span className="px-2 py-1 bg-gray-700 text-purple-400 text-xs font-mono border border-gray-600">
+                      cryptography
+                    </span>
+                    <span className="px-2 py-1 bg-gray-700 text-green-400 text-xs font-mono border border-gray-600">
+                      forensics
+                    </span>
+                    <span className="px-2 py-1 bg-gray-700 text-orange-400 text-xs font-mono border border-gray-600">
+                      network-analysis
+                    </span>
                   </div>
-                  <div className="text-xs text-gray-500">
-                    <span className="text-yellow-400">2 writeups</span> • Real IP Heist, Challenge #2
+                  <div className="text-xs text-cyan-400 font-mono mb-2">
+                    cd /ctf/safaricom2025 && cat writeup.md
+                  </div>
+                  <div className="flex items-center justify-between text-xs text-gray-500">
+                    <span>
+                      Date: <span className="text-cyan-400">Oct 6, 2025</span>
+                    </span>
+                    <span>
+                      Writeups:{" "}
+                      <span className="text-yellow-400">2 Available</span>
+                    </span>
                   </div>
                 </div>
               </div>

--- a/src/pages/GetStartedPage.jsx
+++ b/src/pages/GetStartedPage.jsx
@@ -211,6 +211,68 @@ export default function GetStartedPage() {
           </div>
         </div>
 
+        {/* CTF Writeups Section */}
+        <div className="mt-12 w-full max-w-md">
+          <div className="mb-6">
+            <h2 className="text-xl font-semibold text-gray-300 mb-2 flex items-center">
+              <Shield className="w-5 h-5 text-cyan-400 mr-2" />
+              ./ctf_writeups
+            </h2>
+            <p className="text-gray-500 text-sm font-mono">
+              # Capture The Flag competitions and challenge writeups
+            </p>
+          </div>
+
+          <div className="space-y-4">
+            {/* Safaricom CTF - October 2025 */}
+            <div
+              className="bg-gray-800 border border-gray-700 hover:border-cyan-500 text-left p-6 transition-all duration-200 group cursor-pointer"
+              onClick={() => navigate("/ctf/safaricom-2025")}
+            >
+              <div className="flex items-start">
+                <Terminal className="w-6 h-6 text-cyan-400 mr-4 mt-1 group-hover:text-cyan-300" />
+                <div className="w-full">
+                  <div className="flex items-center justify-between mb-2">
+                    <h3 className="text-lg font-semibold text-gray-300 group-hover:text-cyan-300">
+                      ./safaricom_ctf_2025
+                    </h3>
+                    <span className="text-xs text-green-400 px-2 py-1 bg-gray-700 border border-gray-600 font-mono">
+                      FRESH
+                    </span>
+                  </div>
+                  <p className="text-gray-500 text-sm leading-relaxed mb-3">
+                    Capture The Flag competition writeups - October 6, 2025
+                  </p>
+                  <div className="text-xs text-cyan-400 font-mono mb-2">
+                    cd /ctf/safaricom2025 && ls writeups/
+                  </div>
+                  <div className="text-xs text-gray-500">
+                    <span className="text-yellow-400">2 writeups</span> • Real IP Heist, Challenge #2
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Placeholder for future CTFs */}
+            <div className="bg-gray-800 border border-gray-700 border-dashed text-left p-6 opacity-60">
+              <div className="flex items-start">
+                <Terminal className="w-6 h-6 text-gray-500 mr-4 mt-1" />
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-500 mb-2">
+                    ./upcoming_ctfs
+                  </h3>
+                  <p className="text-gray-600 text-sm leading-relaxed mb-3">
+                    More CTF writeups and competition results coming soon...
+                  </p>
+                  <div className="text-xs text-gray-600 font-mono">
+                    watch -n 1 "find /ctf -name '*.md' | wc -l"
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
         {/* Terminal Style Info */}
         <div className="mt-12 max-w-md text-center">
           <div className="bg-gray-800 border border-gray-700 p-4 text-left">

--- a/src/pages/RealIPHeistWriteup.jsx
+++ b/src/pages/RealIPHeistWriteup.jsx
@@ -1,0 +1,455 @@
+import { useNavigate } from "react-router-dom";
+import {
+  Terminal,
+  Shield,
+  ArrowLeft,
+  Copy,
+  ExternalLink,
+  Flag,
+  Clock,
+} from "lucide-react";
+import { useState } from "react";
+
+export default function RealIPHeistWriteup() {
+  const navigate = useNavigate();
+  const [copiedText, setCopiedText] = useState("");
+
+  const copyToClipboard = (text, identifier) => {
+    navigator.clipboard.writeText(text);
+    setCopiedText(identifier);
+    setTimeout(() => setCopiedText(""), 2000);
+  };
+
+  const CodeBlock = ({ children, identifier, language = "bash" }) => (
+    <div className="relative">
+      <div className="bg-gray-900 border border-gray-600 rounded overflow-hidden">
+        <div className="flex items-center justify-between bg-gray-800 px-4 py-2 border-b border-gray-600">
+          <span className="text-gray-400 text-sm font-mono">{language}</span>
+          <button
+            onClick={() => copyToClipboard(children, identifier)}
+            className="flex items-center text-gray-400 hover:text-cyan-400 transition-colors text-sm"
+          >
+            <Copy className="w-4 h-4 mr-1" />
+            {copiedText === identifier ? "Copied!" : "Copy"}
+          </button>
+        </div>
+        <pre className="p-4 text-sm font-mono text-gray-300 overflow-x-auto">
+          <code>{children}</code>
+        </pre>
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-gray-300 font-mono">
+      {/* Navbar Header */}
+      <nav className="bg-gray-900 border-b border-gray-700 px-4 sm:px-6 py-4">
+        <div className="max-w-4xl mx-auto">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            {/* Left side - Logo */}
+            <div className="flex flex-col">
+              <div className="flex items-center">
+                <Terminal className="w-6 h-6 sm:w-8 sm:h-8 text-red-400 mr-2 sm:mr-3" />
+                <h1
+                  className="text-xl sm:text-2xl font-bold text-gray-300 cursor-pointer"
+                  onClick={() => navigate("/")}
+                >
+                  secure<span className="text-red-400">cloud</span>X
+                </h1>
+              </div>
+              <div className="ml-8 sm:ml-11 hidden sm:block">
+                <p className="text-gray-500 text-sm">
+                  // Real IP Heist - Safaricom CTF 2025 Writeup
+                </p>
+                <div className="text-xs text-gray-600 mt-1">
+                  root@securecloudx:~# cat /ctf/safaricom2025/real-ip-heist.md
+                </div>
+              </div>
+            </div>
+
+            {/* Right side - Navigation Links */}
+            <div className="flex items-center justify-start sm:justify-end space-x-4 sm:space-x-6 ml-8 sm:ml-0">
+              <button
+                className="text-gray-300 hover:text-red-400 transition-colors duration-200 text-xs sm:text-sm font-mono"
+                onClick={() => navigate("/ctf/safaricom-2025")}
+              >
+                ../safaricom_ctf
+              </button>
+              <button
+                className="text-gray-300 hover:text-red-400 transition-colors duration-200 text-xs sm:text-sm font-mono"
+                onClick={() => navigate("/get-started")}
+              >
+                ../get_started
+              </button>
+            </div>
+          </div>
+        </div>
+      </nav>
+
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        {/* Back Navigation */}
+        <div className="mb-8">
+          <button
+            className="inline-flex items-center px-4 py-2 bg-gray-800 border border-gray-700 text-gray-300 font-mono hover:bg-gray-700 hover:border-gray-600 transition-colors group"
+            onClick={() => navigate("/ctf/safaricom-2025")}
+          >
+            <ArrowLeft className="w-4 h-4 mr-2 group-hover:-translate-x-1 transition-transform" />
+            cd ../safaricom_ctf/
+          </button>
+        </div>
+
+        {/* Header Section */}
+        <div className="mb-8">
+          <div className="flex items-center mb-4">
+            <Shield className="w-8 h-8 text-cyan-400 mr-3" />
+            <h1 className="text-3xl font-bold text-gray-300">Real IP Heist</h1>
+            <span className="ml-4 px-3 py-1 bg-green-600 text-white text-sm font-mono rounded">
+              SOLVED
+            </span>
+          </div>
+
+          <div className="bg-gray-800 border border-gray-700 p-4 rounded mb-6">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+              <div className="flex items-center">
+                <Flag className="w-4 h-4 text-green-400 mr-2" />
+                <span className="text-gray-400">Points:</span>
+                <span className="text-green-400 ml-2">50</span>
+              </div>
+              <div className="flex items-center">
+                <Clock className="w-4 h-4 text-cyan-400 mr-2" />
+                <span className="text-gray-400">Category:</span>
+                <span className="text-cyan-400 ml-2">Web Exploitation</span>
+              </div>
+              <div className="flex items-center">
+                <ExternalLink className="w-4 h-4 text-yellow-400 mr-2" />
+                <span className="text-gray-400">Target:</span>
+                <span className="text-yellow-400 ml-2">54.72.82.22:8085</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Challenge Summary */}
+        <div className="mb-8">
+          <h2 className="text-xl font-semibold text-gray-300 mb-4 flex items-center">
+            <Terminal className="w-5 h-5 text-cyan-400 mr-2" />
+            ./summary
+          </h2>
+          <div className="bg-gray-800 border border-gray-700 p-6 rounded">
+            <p className="text-gray-400 leading-relaxed mb-4">
+              We exploited a server-side trust in IP-related headers (e.g.{" "}
+              <code className="text-cyan-400 bg-gray-700 px-1 rounded">
+                X-Forwarded-For
+              </code>
+              ) to make the application treat our requests as coming from an
+              internal/localhost address. The app used that perceived IP (or
+              access level sent in the login form) to gate an admin panel. By
+              spoofing appropriate headers when requesting
+              <code className="text-cyan-400 bg-gray-700 px-1 rounded">
+                /admin
+              </code>
+              , we were granted admin access and the flag was revealed.
+            </p>
+            <div className="bg-gray-900 border border-gray-600 p-4 rounded">
+              <div className="text-green-400 text-sm mb-2">$ echo $FLAG</div>
+              <div className="text-yellow-400 font-mono">
+                safctf{"{c0f1ec1fccb2de4a03031037251f21}"}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Tools Used */}
+        <div className="mb-8">
+          <h2 className="text-xl font-semibold text-gray-300 mb-4 flex items-center">
+            <Terminal className="w-5 h-5 text-cyan-400 mr-2" />
+            ./tools_used
+          </h2>
+          <div className="bg-gray-800 border border-gray-700 p-6 rounded">
+            <ul className="space-y-2">
+              <li className="flex items-center">
+                <span className="text-cyan-400 mr-3">•</span>
+                <code className="text-gray-300">curl</code>
+                <span className="text-gray-400 ml-2">
+                  (built-in) for all requests
+                </span>
+              </li>
+              <li className="flex items-center">
+                <span className="text-cyan-400 mr-3">•</span>
+                <span className="text-gray-300">Basic inspection with</span>
+                <code className="text-cyan-400 bg-gray-700 px-1 rounded ml-2">
+                  curl -v
+                </code>
+                <span className="text-gray-400 ml-1">and</span>
+                <code className="text-cyan-400 bg-gray-700 px-1 rounded ml-1">
+                  curl -i
+                </code>
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        {/* Reconnaissance */}
+        <div className="mb-8">
+          <h2 className="text-xl font-semibold text-gray-300 mb-4 flex items-center">
+            <Shield className="w-5 h-5 text-yellow-400 mr-2" />
+            ./reconnaissance
+          </h2>
+          <div className="space-y-4">
+            <div className="bg-gray-800 border border-gray-700 p-6 rounded">
+              <p className="text-gray-400 mb-4">
+                1. Fetch the root page and examine returned HTML/JS and server
+                headers:
+              </p>
+              <CodeBlock identifier="recon1">
+                curl -i http://54.72.82.22:8085/
+              </CodeBlock>
+            </div>
+
+            <div className="bg-gray-800 border border-gray-700 p-6 rounded">
+              <h3 className="text-gray-300 font-semibold mb-3">
+                Observations from the page:
+              </h3>
+              <ul className="space-y-2 text-gray-400">
+                <li className="flex items-start">
+                  <span className="text-yellow-400 mr-3 mt-1">•</span>
+                  The HTML contains a login form that posts to{" "}
+                  <code className="text-cyan-400 bg-gray-700 px-1 rounded">
+                    /
+                  </code>
+                  .
+                </li>
+                <li className="flex items-start">
+                  <span className="text-yellow-400 mr-3 mt-1">•</span>
+                  The client-side JS sends the form with an{" "}
+                  <code className="text-cyan-400 bg-gray-700 px-1 rounded">
+                    X-Forwarded-For
+                  </code>{" "}
+                  header (set to{" "}
+                  <code className="text-cyan-400 bg-gray-700 px-1 rounded">
+                    8.8.8.8
+                  </code>{" "}
+                  in the page JS). That strongly suggested the server reads
+                  trustable headers to determine client IP.
+                </li>
+                <li className="flex items-start">
+                  <span className="text-yellow-400 mr-3 mt-1">•</span>A comment
+                  in the HTML (
+                  <code className="text-cyan-400 bg-gray-700 px-1 rounded">
+                    {"<!--x real admins use internal tools -->"}
+                  </code>
+                  ) hinted the admin interface is reachable only by requests
+                  perceived to originate from an internal address (e.g.,{" "}
+                  <code className="text-cyan-400 bg-gray-700 px-1 rounded">
+                    127.0.0.1
+                  </code>
+                  ).
+                </li>
+              </ul>
+            </div>
+
+            <div className="bg-gray-800 border border-gray-700 p-6 rounded">
+              <p className="text-gray-400 mb-4">
+                We also saw the server responded with "Access denied: Admins
+                only....try harder!" for unauthenticated requests — confirming a
+                gate existed.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Initial Tests */}
+        <div className="mb-8">
+          <h2 className="text-xl font-semibold text-gray-300 mb-4 flex items-center">
+            <Terminal className="w-5 h-5 text-purple-400 mr-2" />
+            ./initial_tests
+          </h2>
+          <div className="bg-gray-800 border border-gray-700 p-6 rounded">
+            <p className="text-gray-400 mb-4">
+              We probed a few endpoints and headers to see how the app behaved
+              and which headers it trusted. Example checks:
+            </p>
+            <CodeBlock identifier="initial-tests">
+              curl -i http://54.72.82.22:8085/robots.txt curl -i
+              http://54.72.82.22:8085/admin curl -i http://54.72.82.22:8085/flag
+            </CodeBlock>
+            <p className="text-gray-400 mt-4">
+              We then tested submitting the login form with an{" "}
+              <code className="text-cyan-400 bg-gray-700 px-1 rounded">
+                access_level
+              </code>{" "}
+              of
+              <code className="text-cyan-400 bg-gray-700 px-1 rounded">
+                Admin
+              </code>{" "}
+              while spoofing IP headers. The server responded differently
+              depending on these headers.
+            </p>
+          </div>
+        </div>
+
+        {/* Exploitation */}
+        <div className="mb-8">
+          <h2 className="text-xl font-semibold text-gray-300 mb-4 flex items-center">
+            <Shield className="w-5 h-5 text-red-400 mr-2" />
+            ./exploitation
+          </h2>
+          <div className="space-y-4">
+            <div className="bg-gray-800 border border-gray-700 p-6 rounded">
+              <p className="text-gray-400 mb-4">
+                We used{" "}
+                <code className="text-cyan-400 bg-gray-700 px-1 rounded">
+                  curl
+                </code>{" "}
+                POSTs that mimicked the form submission but injected spoofed IP
+                headers. The successful payloads included headers like{" "}
+                <code className="text-cyan-400 bg-gray-700 px-1 rounded">
+                  X-Forwarded-For
+                </code>{" "}
+                and/or
+                <code className="text-cyan-400 bg-gray-700 px-1 rounded">
+                  X-Real-IP
+                </code>{" "}
+                set to{" "}
+                <code className="text-cyan-400 bg-gray-700 px-1 rounded">
+                  127.0.0.1
+                </code>{" "}
+                (localhost). Example commands used (copied exactly from the
+                terminal):
+              </p>
+
+              <CodeBlock identifier="exploit1">
+                curl -i -X POST http://54.72.82.22:8085/ \ -H "Content-Type:
+                application/x-www-form-urlencoded" \ -H "X-Forwarded-For:
+                127.0.0.1" \ -d "username=attacker&access_level=Admin"
+              </CodeBlock>
+            </div>
+
+            <div className="bg-gray-800 border border-gray-700 p-6 rounded">
+              <p className="text-gray-400 mb-4">
+                And directly requesting the admin panel while spoofing headers:
+              </p>
+              <CodeBlock identifier="exploit2">
+                curl -i http://54.72.82.22:8085/admin \ -H "X-Forwarded-For:
+                127.0.0.1" \ -H "X-Real-IP: 127.0.0.1" \ -H "Host: localhost"
+              </CodeBlock>
+              <p className="text-gray-400 mt-4">
+                Multiple header variants were tried (e.g.{" "}
+                <code className="text-cyan-400 bg-gray-700 px-1 rounded">
+                  Forwarded: for=127.0.0.1
+                </code>
+                ,
+                <code className="text-cyan-400 bg-gray-700 px-1 rounded">
+                  Client-IP
+                </code>
+                ,{" "}
+                <code className="text-cyan-400 bg-gray-700 px-1 rounded">
+                  True-Client-IP
+                </code>
+                , and chained{" "}
+                <code className="text-cyan-400 bg-gray-700 px-1 rounded">
+                  X-Forwarded-For
+                </code>{" "}
+                values). The server accepted requests that presented
+                <code className="text-cyan-400 bg-gray-700 px-1 rounded">
+                  127.0.0.1
+                </code>{" "}
+                in these trusted headers.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Result */}
+        <div className="mb-8">
+          <h2 className="text-xl font-semibold text-gray-300 mb-4 flex items-center">
+            <Flag className="w-5 h-5 text-green-400 mr-2" />
+            ./result
+          </h2>
+          <div className="bg-gray-800 border border-gray-700 p-6 rounded">
+            <p className="text-gray-400 mb-4">
+              The{" "}
+              <code className="text-cyan-400 bg-gray-700 px-1 rounded">
+                /admin
+              </code>{" "}
+              response returned the flag:
+            </p>
+            <div className="bg-gray-900 border border-gray-600 p-4 rounded mb-4">
+              <div className="text-green-400 text-sm mb-2">
+                $ curl -i http://54.72.82.22:8085/admin -H "X-Forwarded-For:
+                127.0.0.1"
+              </div>
+              <div className="text-yellow-400 font-mono text-lg">
+                Flag: safctf{"{c0f1ec1fccb2de4a03031037251f21}"}
+              </div>
+            </div>
+            <p className="text-gray-400 text-sm italic">
+              (Recorded directly from the server response.)
+            </p>
+          </div>
+        </div>
+
+        {/* Key Learnings */}
+        <div className="mb-8">
+          <h2 className="text-xl font-semibold text-gray-300 mb-4 flex items-center">
+            <Terminal className="w-5 h-5 text-green-400 mr-2" />
+            ./key_learnings
+          </h2>
+          <div className="bg-gray-800 border border-gray-700 p-6 rounded">
+            <ul className="space-y-3 text-gray-400">
+              <li className="flex items-start">
+                <span className="text-green-400 mr-3 mt-1">✓</span>
+                <div>
+                  <strong className="text-gray-300">
+                    Never trust client-provided headers for security decisions
+                  </strong>
+                  <br />
+                  Headers like X-Forwarded-For, X-Real-IP can easily be spoofed
+                  by attackers.
+                </div>
+              </li>
+              <li className="flex items-start">
+                <span className="text-green-400 mr-3 mt-1">✓</span>
+                <div>
+                  <strong className="text-gray-300">
+                    IP-based access control is fragile
+                  </strong>
+                  <br />
+                  Applications should use proper authentication and
+                  authorization mechanisms instead of relying on IP addresses.
+                </div>
+              </li>
+              <li className="flex items-start">
+                <span className="text-green-400 mr-3 mt-1">✓</span>
+                <div>
+                  <strong className="text-gray-300">
+                    Always examine HTML comments and client-side code
+                  </strong>
+                  <br />
+                  Developer comments often reveal valuable information about the
+                  application's security model.
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        {/* Footer Navigation */}
+        <div className="flex justify-between items-center pt-8 border-t border-gray-700">
+          <button
+            onClick={() => navigate("/ctf/safaricom-2025")}
+            className="text-gray-400 hover:text-cyan-400 transition-colors text-sm"
+          >
+            ← Back to Safaricom CTF 2025
+          </button>
+          <button
+            onClick={() => navigate("/get-started")}
+            className="text-gray-400 hover:text-cyan-400 transition-colors text-sm"
+          >
+            View All CTFs →
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/RealIPHeistWriteup.jsx
+++ b/src/pages/RealIPHeistWriteup.jsx
@@ -23,17 +23,19 @@ export default function RealIPHeistWriteup() {
   const CodeBlock = ({ children, identifier, language = "bash" }) => (
     <div className="relative">
       <div className="bg-gray-900 border border-gray-600 rounded overflow-hidden">
-        <div className="flex items-center justify-between bg-gray-800 px-4 py-2 border-b border-gray-600">
-          <span className="text-gray-400 text-sm font-mono">{language}</span>
+        <div className="flex items-center justify-between bg-gray-800 px-3 sm:px-4 py-2 border-b border-gray-600">
+          <span className="text-gray-400 text-xs sm:text-sm font-mono">
+            {language}
+          </span>
           <button
             onClick={() => copyToClipboard(children, identifier)}
-            className="flex items-center text-gray-400 hover:text-cyan-400 transition-colors text-sm"
+            className="flex items-center text-gray-400 hover:text-cyan-400 transition-colors text-xs sm:text-sm"
           >
-            <Copy className="w-4 h-4 mr-1" />
+            <Copy className="w-3 sm:w-4 h-3 sm:h-4 mr-1" />
             {copiedText === identifier ? "Copied!" : "Copy"}
           </button>
         </div>
-        <pre className="p-4 text-sm font-mono text-gray-300 overflow-x-auto">
+        <pre className="p-3 sm:p-4 text-xs sm:text-sm font-mono text-gray-300 overflow-x-auto">
           <code>{children}</code>
         </pre>
       </div>
@@ -44,7 +46,7 @@ export default function RealIPHeistWriteup() {
     <div className="min-h-screen bg-gray-900 text-gray-300 font-mono">
       {/* Navbar Header */}
       <nav className="bg-gray-900 border-b border-gray-700 px-4 sm:px-6 py-4">
-        <div className="max-w-4xl mx-auto">
+        <div className="max-w-6xl mx-auto">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
             {/* Left side - Logo */}
             <div className="flex flex-col">
@@ -57,7 +59,7 @@ export default function RealIPHeistWriteup() {
                   secure<span className="text-red-400">cloud</span>X
                 </h1>
               </div>
-              <div className="ml-8 sm:ml-11 hidden sm:block">
+              <div className="ml-8 sm:ml-11 hidden lg:block">
                 <p className="text-gray-500 text-sm">
                   // Real IP Heist - Safaricom CTF 2025 Writeup
                 </p>
@@ -68,15 +70,15 @@ export default function RealIPHeistWriteup() {
             </div>
 
             {/* Right side - Navigation Links */}
-            <div className="flex items-center justify-start sm:justify-end space-x-4 sm:space-x-6 ml-8 sm:ml-0">
+            <div className="flex items-center justify-start sm:justify-end space-x-3 sm:space-x-4 ml-8 sm:ml-0">
               <button
-                className="text-gray-300 hover:text-red-400 transition-colors duration-200 text-xs sm:text-sm font-mono"
+                className="text-gray-300 hover:text-red-400 transition-colors duration-200 text-xs sm:text-sm font-mono whitespace-nowrap"
                 onClick={() => navigate("/ctf/safaricom-2025")}
               >
                 ../safaricom_ctf
               </button>
               <button
-                className="text-gray-300 hover:text-red-400 transition-colors duration-200 text-xs sm:text-sm font-mono"
+                className="text-gray-300 hover:text-red-400 transition-colors duration-200 text-xs sm:text-sm font-mono whitespace-nowrap"
                 onClick={() => navigate("/get-started")}
               >
                 ../get_started
@@ -86,30 +88,34 @@ export default function RealIPHeistWriteup() {
         </div>
       </nav>
 
-      <div className="max-w-4xl mx-auto px-4 py-8">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 py-6 sm:py-8">
         {/* Back Navigation */}
-        <div className="mb-8">
+        <div className="mb-6 sm:mb-8">
           <button
-            className="inline-flex items-center px-4 py-2 bg-gray-800 border border-gray-700 text-gray-300 font-mono hover:bg-gray-700 hover:border-gray-600 transition-colors group"
+            className="inline-flex items-center px-3 sm:px-4 py-2 bg-gray-800 border border-gray-700 text-gray-300 font-mono hover:bg-gray-700 hover:border-gray-600 transition-colors group text-sm sm:text-base"
             onClick={() => navigate("/ctf/safaricom-2025")}
           >
             <ArrowLeft className="w-4 h-4 mr-2 group-hover:-translate-x-1 transition-transform" />
-            cd ../safaricom_ctf/
+            <span className="hidden sm:inline">cd ../safaricom_ctf/</span>
+            <span className="sm:hidden">Back</span>
           </button>
         </div>
-
         {/* Header Section */}
-        <div className="mb-8">
-          <div className="flex items-center mb-4">
-            <Shield className="w-8 h-8 text-cyan-400 mr-3" />
-            <h1 className="text-3xl font-bold text-gray-300">Real IP Heist</h1>
-            <span className="ml-4 px-3 py-1 bg-green-600 text-white text-sm font-mono rounded">
+        <div className="mb-8 sm:mb-12">
+          <div className="flex flex-col sm:flex-row sm:items-center mb-4 gap-2 sm:gap-0">
+            <div className="flex items-center">
+              <Shield className="w-6 sm:w-8 h-6 sm:h-8 text-cyan-400 mr-2 sm:mr-3" />
+              <h1 className="text-2xl sm:text-3xl font-bold text-gray-300">
+                Real IP Heist
+              </h1>
+            </div>
+            <span className="ml-0 sm:ml-4 px-3 py-1 bg-green-600 text-white text-sm font-mono rounded self-start">
               SOLVED
             </span>
           </div>
 
-          <div className="bg-gray-800 border border-gray-700 p-4 rounded mb-6">
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+          <div className="bg-gray-800 border border-gray-700 p-4 sm:p-6 rounded mb-6">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-4 text-sm">
               <div className="flex items-center">
                 <Flag className="w-4 h-4 text-green-400 mr-2" />
                 <span className="text-gray-400">Points:</span>
@@ -120,79 +126,86 @@ export default function RealIPHeistWriteup() {
                 <span className="text-gray-400">Category:</span>
                 <span className="text-cyan-400 ml-2">Web Exploitation</span>
               </div>
-              <div className="flex items-center">
-                <ExternalLink className="w-4 h-4 text-yellow-400 mr-2" />
+              <div className="flex items-center col-span-1 sm:col-span-2 lg:col-span-1">
+                <ExternalLink className="w-4 h-4 text-yellow-400 mr-2 flex-shrink-0" />
                 <span className="text-gray-400">Target:</span>
-                <span className="text-yellow-400 ml-2">54.72.82.22:8085</span>
+                <span className="text-yellow-400 ml-2 break-all">
+                  54.72.82.22:8085
+                </span>
               </div>
             </div>
           </div>
-        </div>
-
+        </div>{" "}
         {/* Challenge Summary */}
-        <div className="mb-8">
-          <h2 className="text-xl font-semibold text-gray-300 mb-4 flex items-center">
-            <Terminal className="w-5 h-5 text-cyan-400 mr-2" />
+        <div className="mb-6 sm:mb-8">
+          <h2 className="text-lg sm:text-xl font-semibold text-gray-300 mb-3 sm:mb-4 flex items-center">
+            <Terminal className="w-4 sm:w-5 h-4 sm:h-5 text-cyan-400 mr-2" />
             ./summary
           </h2>
-          <div className="bg-gray-800 border border-gray-700 p-6 rounded">
-            <p className="text-gray-400 leading-relaxed mb-4">
+          <div className="bg-gray-800 border border-gray-700 p-4 sm:p-6 rounded">
+            <p className="text-gray-400 leading-relaxed mb-4 text-sm sm:text-base">
               We exploited a server-side trust in IP-related headers (e.g.{" "}
-              <code className="text-cyan-400 bg-gray-700 px-1 rounded">
+              <code className="text-cyan-400 bg-gray-700 px-1 rounded text-xs sm:text-sm">
                 X-Forwarded-For
               </code>
               ) to make the application treat our requests as coming from an
               internal/localhost address. The app used that perceived IP (or
               access level sent in the login form) to gate an admin panel. By
-              spoofing appropriate headers when requesting
-              <code className="text-cyan-400 bg-gray-700 px-1 rounded">
+              spoofing appropriate headers when requesting{" "}
+              <code className="text-cyan-400 bg-gray-700 px-1 rounded text-xs sm:text-sm">
                 /admin
               </code>
               , we were granted admin access and the flag was revealed.
             </p>
-            <div className="bg-gray-900 border border-gray-600 p-4 rounded">
-              <div className="text-green-400 text-sm mb-2">$ echo $FLAG</div>
-              <div className="text-yellow-400 font-mono">
+            <div className="bg-gray-900 border border-gray-600 p-3 sm:p-4 rounded overflow-x-auto">
+              <div className="text-green-400 text-xs sm:text-sm mb-2">
+                $ echo $FLAG
+              </div>
+              <div className="text-yellow-400 font-mono text-xs sm:text-sm break-all">
                 safctf{"{c0f1ec1fccb2de4a03031037251f21}"}
               </div>
             </div>
           </div>
         </div>
-
         {/* Tools Used */}
-        <div className="mb-8">
-          <h2 className="text-xl font-semibold text-gray-300 mb-4 flex items-center">
-            <Terminal className="w-5 h-5 text-cyan-400 mr-2" />
+        <div className="mb-6 sm:mb-8">
+          <h2 className="text-lg sm:text-xl font-semibold text-gray-300 mb-3 sm:mb-4 flex items-center">
+            <Terminal className="w-4 sm:w-5 h-4 sm:h-5 text-cyan-400 mr-2" />
             ./tools_used
           </h2>
-          <div className="bg-gray-800 border border-gray-700 p-6 rounded">
-            <ul className="space-y-2">
-              <li className="flex items-center">
-                <span className="text-cyan-400 mr-3">•</span>
-                <code className="text-gray-300">curl</code>
-                <span className="text-gray-400 ml-2">
-                  (built-in) for all requests
-                </span>
+          <div className="bg-gray-800 border border-gray-700 p-4 sm:p-6 rounded">
+            <ul className="space-y-2 sm:space-y-3">
+              <li className="flex items-start sm:items-center">
+                <span className="text-cyan-400 mr-3 mt-1 sm:mt-0">•</span>
+                <div className="flex flex-col sm:flex-row sm:items-center text-sm sm:text-base">
+                  <code className="text-gray-300">curl</code>
+                  <span className="text-gray-400 sm:ml-2">
+                    (built-in) for all requests
+                  </span>
+                </div>
               </li>
-              <li className="flex items-center">
-                <span className="text-cyan-400 mr-3">•</span>
-                <span className="text-gray-300">Basic inspection with</span>
-                <code className="text-cyan-400 bg-gray-700 px-1 rounded ml-2">
-                  curl -v
-                </code>
-                <span className="text-gray-400 ml-1">and</span>
-                <code className="text-cyan-400 bg-gray-700 px-1 rounded ml-1">
-                  curl -i
-                </code>
+              <li className="flex items-start sm:items-center">
+                <span className="text-cyan-400 mr-3 mt-1 sm:mt-0">•</span>
+                <div className="flex flex-col sm:flex-row sm:items-center text-sm sm:text-base">
+                  <span className="text-gray-300">Basic inspection with</span>
+                  <div className="flex flex-wrap gap-1 mt-1 sm:mt-0 sm:ml-2">
+                    <code className="text-cyan-400 bg-gray-700 px-1 rounded text-xs sm:text-sm">
+                      curl -v
+                    </code>
+                    <span className="text-gray-400">and</span>
+                    <code className="text-cyan-400 bg-gray-700 px-1 rounded text-xs sm:text-sm">
+                      curl -i
+                    </code>
+                  </div>
+                </div>
               </li>
             </ul>
           </div>
         </div>
-
         {/* Reconnaissance */}
-        <div className="mb-8">
-          <h2 className="text-xl font-semibold text-gray-300 mb-4 flex items-center">
-            <Shield className="w-5 h-5 text-yellow-400 mr-2" />
+        <div className="mb-6 sm:mb-8">
+          <h2 className="text-lg sm:text-xl font-semibold text-gray-300 mb-3 sm:mb-4 flex items-center">
+            <Shield className="w-4 sm:w-5 h-4 sm:h-5 text-yellow-400 mr-2" />
             ./reconnaissance
           </h2>
           <div className="space-y-4">
@@ -210,40 +223,52 @@ export default function RealIPHeistWriteup() {
               <h3 className="text-gray-300 font-semibold mb-3">
                 Observations from the page:
               </h3>
-              <ul className="space-y-2 text-gray-400">
+              <ul className="space-y-3 text-gray-400">
                 <li className="flex items-start">
-                  <span className="text-yellow-400 mr-3 mt-1">•</span>
-                  The HTML contains a login form that posts to{" "}
-                  <code className="text-cyan-400 bg-gray-700 px-1 rounded">
-                    /
-                  </code>
-                  .
+                  <span className="text-yellow-400 mr-3 mt-0.5 flex-shrink-0">
+                    •
+                  </span>
+                  <div>
+                    The HTML contains a login form that posts to{" "}
+                    <code className="text-cyan-400 bg-gray-700 px-1 rounded text-sm">
+                      /
+                    </code>
+                    .
+                  </div>
                 </li>
                 <li className="flex items-start">
-                  <span className="text-yellow-400 mr-3 mt-1">•</span>
-                  The client-side JS sends the form with an{" "}
-                  <code className="text-cyan-400 bg-gray-700 px-1 rounded">
-                    X-Forwarded-For
-                  </code>{" "}
-                  header (set to{" "}
-                  <code className="text-cyan-400 bg-gray-700 px-1 rounded">
-                    8.8.8.8
-                  </code>{" "}
-                  in the page JS). That strongly suggested the server reads
-                  trustable headers to determine client IP.
+                  <span className="text-yellow-400 mr-3 mt-0.5 flex-shrink-0">
+                    •
+                  </span>
+                  <div>
+                    The client-side JS sends the form with an{" "}
+                    <code className="text-cyan-400 bg-gray-700 px-1 rounded text-sm">
+                      X-Forwarded-For
+                    </code>{" "}
+                    header (set to{" "}
+                    <code className="text-cyan-400 bg-gray-700 px-1 rounded text-sm">
+                      8.8.8.8
+                    </code>{" "}
+                    in the page JS). That strongly suggested the server reads
+                    trustable headers to determine client IP.
+                  </div>
                 </li>
                 <li className="flex items-start">
-                  <span className="text-yellow-400 mr-3 mt-1">•</span>A comment
-                  in the HTML (
-                  <code className="text-cyan-400 bg-gray-700 px-1 rounded">
-                    {"<!--x real admins use internal tools -->"}
-                  </code>
-                  ) hinted the admin interface is reachable only by requests
-                  perceived to originate from an internal address (e.g.,{" "}
-                  <code className="text-cyan-400 bg-gray-700 px-1 rounded">
-                    127.0.0.1
-                  </code>
-                  ).
+                  <span className="text-yellow-400 mr-3 mt-0.5 flex-shrink-0">
+                    •
+                  </span>
+                  <div>
+                    A comment in the HTML (
+                    <code className="text-cyan-400 bg-gray-700 px-1 rounded text-sm">
+                      {"<!--x real admins use internal tools -->"}
+                    </code>
+                    ) hinted the admin interface is reachable only by requests
+                    perceived to originate from an internal address (e.g.,{" "}
+                    <code className="text-cyan-400 bg-gray-700 px-1 rounded text-sm">
+                      127.0.0.1
+                    </code>
+                    ).
+                  </div>
                 </li>
               </ul>
             </div>
@@ -257,11 +282,10 @@ export default function RealIPHeistWriteup() {
             </div>
           </div>
         </div>
-
         {/* Initial Tests */}
-        <div className="mb-8">
-          <h2 className="text-xl font-semibold text-gray-300 mb-4 flex items-center">
-            <Terminal className="w-5 h-5 text-purple-400 mr-2" />
+        <div className="mb-6 sm:mb-8">
+          <h2 className="text-lg sm:text-xl font-semibold text-gray-300 mb-3 sm:mb-4 flex items-center">
+            <Terminal className="w-4 sm:w-5 h-4 sm:h-5 text-purple-400 mr-2" />
             ./initial_tests
           </h2>
           <div className="bg-gray-800 border border-gray-700 p-6 rounded">
@@ -287,11 +311,10 @@ export default function RealIPHeistWriteup() {
             </p>
           </div>
         </div>
-
         {/* Exploitation */}
-        <div className="mb-8">
-          <h2 className="text-xl font-semibold text-gray-300 mb-4 flex items-center">
-            <Shield className="w-5 h-5 text-red-400 mr-2" />
+        <div className="mb-6 sm:mb-8">
+          <h2 className="text-lg sm:text-xl font-semibold text-gray-300 mb-3 sm:mb-4 flex items-center">
+            <Shield className="w-4 sm:w-5 h-4 sm:h-5 text-red-400 mr-2" />
             ./exploitation
           </h2>
           <div className="space-y-4">
@@ -359,11 +382,10 @@ export default function RealIPHeistWriteup() {
             </div>
           </div>
         </div>
-
         {/* Result */}
-        <div className="mb-8">
-          <h2 className="text-xl font-semibold text-gray-300 mb-4 flex items-center">
-            <Flag className="w-5 h-5 text-green-400 mr-2" />
+        <div className="mb-6 sm:mb-8">
+          <h2 className="text-lg sm:text-xl font-semibold text-gray-300 mb-3 sm:mb-4 flex items-center">
+            <Flag className="w-4 sm:w-5 h-4 sm:h-5 text-green-400 mr-2" />
             ./result
           </h2>
           <div className="bg-gray-800 border border-gray-700 p-6 rounded">
@@ -388,11 +410,10 @@ export default function RealIPHeistWriteup() {
             </p>
           </div>
         </div>
-
         {/* Key Learnings */}
-        <div className="mb-8">
-          <h2 className="text-xl font-semibold text-gray-300 mb-4 flex items-center">
-            <Terminal className="w-5 h-5 text-green-400 mr-2" />
+        <div className="mb-6 sm:mb-8">
+          <h2 className="text-lg sm:text-xl font-semibold text-gray-300 mb-3 sm:mb-4 flex items-center">
+            <Terminal className="w-4 sm:w-5 h-4 sm:h-5 text-green-400 mr-2" />
             ./key_learnings
           </h2>
           <div className="bg-gray-800 border border-gray-700 p-6 rounded">
@@ -433,9 +454,8 @@ export default function RealIPHeistWriteup() {
             </ul>
           </div>
         </div>
-
         {/* Footer Navigation */}
-        <div className="flex justify-between items-center pt-8 border-t border-gray-700">
+        <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 pt-6 sm:pt-8 border-t border-gray-700">
           <button
             onClick={() => navigate("/ctf/safaricom-2025")}
             className="text-gray-400 hover:text-cyan-400 transition-colors text-sm"

--- a/src/pages/SafaricomCTF2025.jsx
+++ b/src/pages/SafaricomCTF2025.jsx
@@ -16,7 +16,7 @@ export default function SafaricomCTF2025() {
     <div className="min-h-screen bg-gray-900 text-gray-300 font-mono">
       {/* Navbar Header */}
       <nav className="bg-gray-900 border-b border-gray-700 px-4 sm:px-6 py-4">
-        <div className="max-w-4xl mx-auto">
+        <div className="max-w-6xl mx-auto">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
             {/* Left side - Logo */}
             <div className="flex flex-col">
@@ -29,7 +29,7 @@ export default function SafaricomCTF2025() {
                   secure<span className="text-red-400">cloud</span>X
                 </h1>
               </div>
-              <div className="ml-8 sm:ml-11 hidden sm:block">
+              <div className="ml-8 sm:ml-11 hidden lg:block">
                 <p className="text-gray-500 text-sm">
                   // Safaricom CTF 2025 - Challenge Writeups
                 </p>
@@ -40,15 +40,15 @@ export default function SafaricomCTF2025() {
             </div>
 
             {/* Right side - Navigation Links */}
-            <div className="flex items-center justify-start sm:justify-end space-x-4 sm:space-x-6 ml-8 sm:ml-0">
+            <div className="flex items-center justify-start sm:justify-end space-x-3 sm:space-x-4 ml-8 sm:ml-0">
               <button
-                className="text-gray-300 hover:text-red-400 transition-colors duration-200 text-xs sm:text-sm font-mono"
+                className="text-gray-300 hover:text-red-400 transition-colors duration-200 text-xs sm:text-sm font-mono whitespace-nowrap"
                 onClick={() => navigate("/get-started")}
               >
                 ../get_started
               </button>
               <button
-                className="text-gray-300 hover:text-red-400 transition-colors duration-200 text-xs sm:text-sm font-mono"
+                className="text-gray-300 hover:text-red-400 transition-colors duration-200 text-xs sm:text-sm font-mono whitespace-nowrap"
                 onClick={() => navigate("/opensource-blog")}
               >
                 ./blog
@@ -58,51 +58,57 @@ export default function SafaricomCTF2025() {
         </div>
       </nav>
 
-      <div className="max-w-4xl mx-auto px-4 py-8">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 py-6 sm:py-8">
         {/* Back Navigation */}
-        <div className="mb-8">
+        <div className="mb-6 sm:mb-8">
           <button
-            className="inline-flex items-center px-4 py-2 bg-gray-800 border border-gray-700 text-gray-300 font-mono hover:bg-gray-700 hover:border-gray-600 transition-colors group"
+            className="inline-flex items-center px-3 sm:px-4 py-2 bg-gray-800 border border-gray-700 text-gray-300 font-mono hover:bg-gray-700 hover:border-gray-600 transition-colors group text-sm sm:text-base"
             onClick={() => navigate("/get-started")}
           >
             <ArrowLeft className="w-4 h-4 mr-2 group-hover:-translate-x-1 transition-transform" />
-            cd ../
+            <span className="hidden sm:inline">cd ../</span>
+            <span className="sm:hidden">Back</span>
           </button>
         </div>
 
         {/* Header Section */}
-        <div className="mb-12">
-          <div className="flex items-center mb-4">
-            <Shield className="w-8 h-8 text-cyan-400 mr-3" />
-            <h1 className="text-3xl font-bold text-gray-300">
-              Safaricom CTF 2025
-            </h1>
-            <span className="ml-4 px-3 py-1 bg-green-600 text-white text-sm font-mono rounded">
+        <div className="mb-8 sm:mb-12">
+          <div className="flex flex-col sm:flex-row sm:items-center mb-4 gap-2 sm:gap-0">
+            <div className="flex items-center">
+              <Shield className="w-6 sm:w-8 h-6 sm:h-8 text-cyan-400 mr-2 sm:mr-3" />
+              <h1 className="text-2xl sm:text-3xl font-bold text-gray-300">
+                Safaricom CTF 2025
+              </h1>
+            </div>
+            <span className="ml-0 sm:ml-4 px-3 py-1 bg-green-600 text-white text-sm font-mono rounded self-start">
               Oct 6, 2025
             </span>
           </div>
 
-          <p className="text-gray-400 text-lg">
-            Challenge writeups from the Safaricom Capture The Flag competition for our team 404FlagNotFound. This was my first CTF competition experience and I learned a lot! We captured 13 flags and we were ranked 49/174 teams.
+          <p className="text-gray-400 text-base sm:text-lg leading-relaxed">
+            Challenge writeups from the Safaricom Capture The Flag competition
+            for our team 404FlagNotFound. This was my first CTF competition
+            experience and I learned a lot! We captured 13 flags and we were
+            ranked 49/174 teams.
           </p>
         </div>
 
         {/* Challenge Writeups */}
-        <div className="mb-12">
-          <h2 className="text-xl font-semibold text-gray-300 mb-6 flex items-center">
-            <Terminal className="w-5 h-5 text-cyan-400 mr-2" />
+        <div className="mb-8 sm:mb-12">
+          <h2 className="text-lg sm:text-xl font-semibold text-gray-300 mb-4 sm:mb-6 flex items-center">
+            <Terminal className="w-4 sm:w-5 h-4 sm:h-5 text-cyan-400 mr-2" />
             ./writeups
           </h2>
 
-          <div className="space-y-4">
+          <div className="space-y-4 sm:space-y-6">
             {/* Real IP Heist Challenge */}
-            <div className="bg-gray-800 border border-gray-700 p-6 rounded hover:border-cyan-500 transition-colors">
-              <div className="flex items-center justify-between mb-3">
+            <div className="bg-gray-800 border border-gray-700 p-4 sm:p-6 rounded hover:border-cyan-500 transition-colors">
+              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-3 gap-2 sm:gap-0">
                 <h3 className="text-lg font-semibold text-cyan-400">
                   Real IP Heist
                 </h3>
-                <div className="flex items-center space-x-3">
-                  <span className="px-2 py-1 bg-gray-700 text-cyan-400 text-xs font-mono">
+                <div className="flex items-center space-x-2 sm:space-x-3">
+                  <span className="px-2 py-1 bg-gray-700 text-cyan-400 text-xs font-mono rounded">
                     web-exploitation
                   </span>
                   <span className="text-green-400 text-sm font-mono">
@@ -111,21 +117,21 @@ export default function SafaricomCTF2025() {
                 </div>
               </div>
 
-              <p className="text-gray-400 mb-4 text-sm">
+              <p className="text-gray-400 mb-4 text-sm sm:text-base">
                 Bypassed admin authentication by spoofing X-Forwarded-For
                 headers to appear as localhost requests.
               </p>
 
-              <div className="flex items-center justify-between">
-                <span className="text-xs text-gray-500">
+              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 sm:gap-0">
+                <div className="text-xs text-gray-500 order-2 sm:order-1">
                   Flag:{" "}
-                  <code className="text-yellow-400">
+                  <code className="text-yellow-400 break-all">
                     safctf{"{c0f1ec1fccb2de4a03031037251f21}"}
                   </code>
-                </span>
+                </div>
                 <button
                   onClick={() => navigate("/ctf/safaricom-2025/real-ip-heist")}
-                  className="inline-flex items-center px-3 py-1 bg-cyan-600 hover:bg-cyan-700 text-white text-xs font-mono rounded transition-colors"
+                  className="inline-flex items-center px-3 py-1 bg-cyan-600 hover:bg-cyan-700 text-white text-xs font-mono rounded transition-colors self-start sm:self-auto order-1 sm:order-2"
                 >
                   Read More →
                 </button>
@@ -133,12 +139,12 @@ export default function SafaricomCTF2025() {
             </div>
 
             {/* Second Challenge Placeholder */}
-            <div className="bg-gray-800 border border-gray-700 p-6 rounded border-dashed opacity-60">
-              <div className="flex items-center justify-between mb-3">
+            <div className="bg-gray-800 border border-gray-700 p-4 sm:p-6 rounded border-dashed opacity-60">
+              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-3 gap-2 sm:gap-0">
                 <h3 className="text-lg font-semibold text-gray-500">
                   Challenge #2
                 </h3>
-                <span className="text-gray-500 text-sm font-mono">
+                <span className="text-gray-500 text-sm font-mono self-start sm:self-auto">
                   Coming soon
                 </span>
               </div>
@@ -151,7 +157,7 @@ export default function SafaricomCTF2025() {
         </div>
 
         {/* Footer Navigation */}
-        <div className="flex justify-between items-center pt-8 border-t border-gray-700">
+        <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 pt-6 sm:pt-8 border-t border-gray-700">
           <button
             onClick={() => navigate("/get-started")}
             className="text-gray-400 hover:text-cyan-400 transition-colors text-sm"

--- a/src/pages/SafaricomCTF2025.jsx
+++ b/src/pages/SafaricomCTF2025.jsx
@@ -1,0 +1,323 @@
+import { useNavigate } from "react-router-dom";
+import {
+  Terminal,
+  Shield,
+  ArrowLeft,
+  Flag,
+  Clock,
+  Trophy,
+  ExternalLink,
+} from "lucide-react";
+
+export default function SafaricomCTF2025() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-gray-300 font-mono">
+      {/* Navbar Header */}
+      <nav className="bg-gray-900 border-b border-gray-700 px-4 sm:px-6 py-4">
+        <div className="max-w-4xl mx-auto">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            {/* Left side - Logo */}
+            <div className="flex flex-col">
+              <div className="flex items-center">
+                <Terminal className="w-6 h-6 sm:w-8 sm:h-8 text-red-400 mr-2 sm:mr-3" />
+                <h1
+                  className="text-xl sm:text-2xl font-bold text-gray-300 cursor-pointer"
+                  onClick={() => navigate("/")}
+                >
+                  secure<span className="text-red-400">cloud</span>X
+                </h1>
+              </div>
+              <div className="ml-8 sm:ml-11 hidden sm:block">
+                <p className="text-gray-500 text-sm">
+                  // Safaricom CTF 2025 - Challenge Writeups
+                </p>
+                <div className="text-xs text-gray-600 mt-1">
+                  root@securecloudx:~# cd /ctf/safaricom2025/
+                </div>
+              </div>
+            </div>
+
+            {/* Right side - Navigation Links */}
+            <div className="flex items-center justify-start sm:justify-end space-x-4 sm:space-x-6 ml-8 sm:ml-0">
+              <button
+                className="text-gray-300 hover:text-red-400 transition-colors duration-200 text-xs sm:text-sm font-mono"
+                onClick={() => navigate("/get-started")}
+              >
+                ../get_started
+              </button>
+              <button
+                className="text-gray-300 hover:text-red-400 transition-colors duration-200 text-xs sm:text-sm font-mono"
+                onClick={() => navigate("/opensource-blog")}
+              >
+                ./blog
+              </button>
+            </div>
+          </div>
+        </div>
+      </nav>
+
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        {/* Back Navigation */}
+        <div className="mb-8">
+          <button
+            className="inline-flex items-center px-4 py-2 bg-gray-800 border border-gray-700 text-gray-300 font-mono hover:bg-gray-700 hover:border-gray-600 transition-colors group"
+            onClick={() => navigate("/get-started")}
+          >
+            <ArrowLeft className="w-4 h-4 mr-2 group-hover:-translate-x-1 transition-transform" />
+            cd ../
+          </button>
+        </div>
+
+        {/* Header Section */}
+        <div className="mb-12">
+          <div className="flex items-center mb-4">
+            <Shield className="w-8 h-8 text-cyan-400 mr-3" />
+            <h1 className="text-3xl font-bold text-gray-300">
+              Safaricom CTF 2025
+            </h1>
+            <span className="ml-4 px-3 py-1 bg-green-600 text-white text-sm font-mono rounded">
+              FRESH
+            </span>
+          </div>
+
+          <div className="bg-gray-800 border border-gray-700 p-6 rounded">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+              <div className="flex items-center">
+                <Clock className="w-4 h-4 text-cyan-400 mr-2" />
+                <span className="text-gray-400">Date:</span>
+                <span className="text-cyan-400 ml-2">October 6, 2025</span>
+              </div>
+              <div className="flex items-center">
+                <Trophy className="w-4 h-4 text-yellow-400 mr-2" />
+                <span className="text-gray-400">Challenges Solved:</span>
+                <span className="text-yellow-400 ml-2">2</span>
+              </div>
+              <div className="flex items-center">
+                <Flag className="w-4 h-4 text-green-400 mr-2" />
+                <span className="text-gray-400">Points Earned:</span>
+                <span className="text-green-400 ml-2">100+</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* CTF Overview */}
+        <div className="mb-12">
+          <h2 className="text-xl font-semibold text-gray-300 mb-4 flex items-center">
+            <Terminal className="w-5 h-5 text-cyan-400 mr-2" />
+            ./competition_overview
+          </h2>
+          <div className="bg-gray-800 border border-gray-700 p-6 rounded">
+            <p className="text-gray-400 leading-relaxed mb-4">
+              Participated in the Safaricom Capture The Flag competition,
+              tackling various cybersecurity challenges across multiple domains
+              including web exploitation, cryptography, forensics, and network
+              analysis.
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <span className="px-3 py-1 bg-gray-700 text-cyan-400 text-sm font-mono border border-gray-600 rounded">
+                web-exploitation
+              </span>
+              <span className="px-3 py-1 bg-gray-700 text-purple-400 text-sm font-mono border border-gray-600 rounded">
+                cryptography
+              </span>
+              <span className="px-3 py-1 bg-gray-700 text-green-400 text-sm font-mono border border-gray-600 rounded">
+                forensics
+              </span>
+              <span className="px-3 py-1 bg-gray-700 text-orange-400 text-sm font-mono border border-gray-600 rounded">
+                network-analysis
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {/* Challenge Writeups */}
+        <div className="mb-12">
+          <h2 className="text-xl font-semibold text-gray-300 mb-6 flex items-center">
+            <Shield className="w-5 h-5 text-cyan-400 mr-2" />
+            ./challenge_writeups
+          </h2>
+
+          <div className="space-y-6">
+            {/* Real IP Heist Challenge */}
+            <div className="bg-gray-800 border border-gray-700 rounded overflow-hidden">
+              <div className="bg-gray-700 px-6 py-3 border-b border-gray-600">
+                <div className="flex items-center justify-between">
+                  <h3 className="text-lg font-semibold text-cyan-400">
+                    Real IP Heist
+                  </h3>
+                  <div className="flex items-center space-x-4">
+                    <span className="px-2 py-1 bg-gray-600 text-cyan-400 text-xs font-mono rounded">
+                      web-exploitation
+                    </span>
+                    <span className="text-green-400 text-sm font-mono">
+                      50 points
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              <div className="p-6">
+                <p className="text-gray-400 mb-4">
+                  Exploited server-side trust in IP-related headers
+                  (X-Forwarded-For) to bypass admin authentication by spoofing
+                  internal/localhost addresses.
+                </p>
+
+                <div className="bg-gray-900 border border-gray-600 p-4 rounded mb-4">
+                  <div className="text-green-400 text-sm mb-2">
+                    $ cat target_info.txt
+                  </div>
+                  <div className="text-gray-300 text-sm font-mono">
+                    Target: http://54.72.82.22:8085/
+                    <br />
+                    Flag: safctf{"{c0f1ec1fccb2de4a03031037251f21}"}
+                  </div>
+                </div>
+
+                <div className="space-y-3">
+                  <div className="flex items-center text-sm">
+                    <span className="text-gray-400 w-20">Tools:</span>
+                    <span className="text-gray-300">
+                      curl, basic HTTP header manipulation
+                    </span>
+                  </div>
+                  <div className="flex items-center text-sm">
+                    <span className="text-gray-400 w-20">Method:</span>
+                    <span className="text-gray-300">
+                      IP header spoofing, admin panel access
+                    </span>
+                  </div>
+                  <div className="flex items-center text-sm">
+                    <span className="text-gray-400 w-20">Status:</span>
+                    <span className="text-green-400">✓ SOLVED</span>
+                  </div>
+                </div>
+
+                <button
+                  onClick={() => navigate("/ctf/safaricom-2025/real-ip-heist")}
+                  className="mt-4 inline-flex items-center px-4 py-2 bg-cyan-600 hover:bg-cyan-700 text-white text-sm font-mono rounded transition-colors"
+                >
+                  <ExternalLink className="w-4 h-4 mr-2" />
+                  View Full Writeup
+                </button>
+              </div>
+            </div>
+
+            {/* Second Challenge Placeholder */}
+            <div className="bg-gray-800 border border-gray-700 rounded overflow-hidden">
+              <div className="bg-gray-700 px-6 py-3 border-b border-gray-600">
+                <div className="flex items-center justify-between">
+                  <h3 className="text-lg font-semibold text-cyan-400">
+                    Challenge #2
+                  </h3>
+                  <div className="flex items-center space-x-4">
+                    <span className="px-2 py-1 bg-gray-600 text-purple-400 text-xs font-mono rounded">
+                      category-tbd
+                    </span>
+                    <span className="text-green-400 text-sm font-mono">
+                      XX points
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              <div className="p-6">
+                <p className="text-gray-400 mb-4">
+                  Details of your second challenge writeup will be added here...
+                </p>
+
+                <div className="bg-gray-900 border border-gray-600 p-4 rounded mb-4">
+                  <div className="text-green-400 text-sm mb-2">
+                    $ cat challenge2_info.txt
+                  </div>
+                  <div className="text-gray-300 text-sm font-mono">
+                    Target: TBD
+                    <br />
+                    Flag: TBD
+                  </div>
+                </div>
+
+                <div className="space-y-3">
+                  <div className="flex items-center text-sm">
+                    <span className="text-gray-400 w-20">Tools:</span>
+                    <span className="text-gray-300">TBD</span>
+                  </div>
+                  <div className="flex items-center text-sm">
+                    <span className="text-gray-400 w-20">Method:</span>
+                    <span className="text-gray-300">TBD</span>
+                  </div>
+                  <div className="flex items-center text-sm">
+                    <span className="text-gray-400 w-20">Status:</span>
+                    <span className="text-green-400">✓ SOLVED</span>
+                  </div>
+                </div>
+
+                <button className="mt-4 inline-flex items-center px-4 py-2 bg-cyan-600 hover:bg-cyan-700 text-white text-sm font-mono rounded transition-colors">
+                  <ExternalLink className="w-4 h-4 mr-2" />
+                  View Full Writeup
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Terminal Output Section */}
+        <div className="mb-12">
+          <h2 className="text-xl font-semibold text-gray-300 mb-4 flex items-center">
+            <Terminal className="w-5 h-5 text-green-400 mr-2" />
+            ./terminal_session
+          </h2>
+          <div className="bg-black border border-gray-600 p-4 rounded font-mono text-sm overflow-x-auto">
+            <div className="text-green-400">
+              root@securecloudx:~/ctf/safaricom2025#
+            </div>
+            <div className="text-gray-300 mt-2">
+              <span className="text-cyan-400">$</span> ls -la writeups/
+              <br />
+              total 2<br />
+              -rw-r--r-- 1 hacker hacker 4096 Oct 6 23:32 real-ip-heist.md
+              <br />
+              -rw-r--r-- 1 hacker hacker 3847 Oct 6 23:45 challenge2.md
+              <br />
+              <br />
+              <span className="text-cyan-400">$</span> wc -l writeups/*.md
+              <br />
+              <span className="text-yellow-400"> 127</span>{" "}
+              writeups/real-ip-heist.md
+              <br />
+              <span className="text-yellow-400"> 98</span>{" "}
+              writeups/challenge2.md
+              <br />
+              <span className="text-yellow-400"> 225</span> total
+              <br />
+              <br />
+              <span className="text-cyan-400">$</span> echo "CTF session
+              complete!"
+              <br />
+              <span className="text-green-400">CTF session complete!</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Footer Navigation */}
+        <div className="flex justify-between items-center pt-8 border-t border-gray-700">
+          <button
+            onClick={() => navigate("/get-started")}
+            className="text-gray-400 hover:text-cyan-400 transition-colors text-sm"
+          >
+            ← Back to CTF List
+          </button>
+          <button
+            onClick={() => navigate("/opensource-blog")}
+            className="text-gray-400 hover:text-cyan-400 transition-colors text-sm"
+          >
+            View More Writeups →
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/SafaricomCTF2025.jsx
+++ b/src/pages/SafaricomCTF2025.jsx
@@ -78,226 +78,74 @@ export default function SafaricomCTF2025() {
               Safaricom CTF 2025
             </h1>
             <span className="ml-4 px-3 py-1 bg-green-600 text-white text-sm font-mono rounded">
-              FRESH
+              Oct 6, 2025
             </span>
           </div>
 
-          <div className="bg-gray-800 border border-gray-700 p-6 rounded">
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
-              <div className="flex items-center">
-                <Clock className="w-4 h-4 text-cyan-400 mr-2" />
-                <span className="text-gray-400">Date:</span>
-                <span className="text-cyan-400 ml-2">October 6, 2025</span>
-              </div>
-              <div className="flex items-center">
-                <Trophy className="w-4 h-4 text-yellow-400 mr-2" />
-                <span className="text-gray-400">Challenges Solved:</span>
-                <span className="text-yellow-400 ml-2">2</span>
-              </div>
-              <div className="flex items-center">
-                <Flag className="w-4 h-4 text-green-400 mr-2" />
-                <span className="text-gray-400">Points Earned:</span>
-                <span className="text-green-400 ml-2">100+</span>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {/* CTF Overview */}
-        <div className="mb-12">
-          <h2 className="text-xl font-semibold text-gray-300 mb-4 flex items-center">
-            <Terminal className="w-5 h-5 text-cyan-400 mr-2" />
-            ./competition_overview
-          </h2>
-          <div className="bg-gray-800 border border-gray-700 p-6 rounded">
-            <p className="text-gray-400 leading-relaxed mb-4">
-              Participated in the Safaricom Capture The Flag competition,
-              tackling various cybersecurity challenges across multiple domains
-              including web exploitation, cryptography, forensics, and network
-              analysis.
-            </p>
-            <div className="flex flex-wrap gap-2">
-              <span className="px-3 py-1 bg-gray-700 text-cyan-400 text-sm font-mono border border-gray-600 rounded">
-                web-exploitation
-              </span>
-              <span className="px-3 py-1 bg-gray-700 text-purple-400 text-sm font-mono border border-gray-600 rounded">
-                cryptography
-              </span>
-              <span className="px-3 py-1 bg-gray-700 text-green-400 text-sm font-mono border border-gray-600 rounded">
-                forensics
-              </span>
-              <span className="px-3 py-1 bg-gray-700 text-orange-400 text-sm font-mono border border-gray-600 rounded">
-                network-analysis
-              </span>
-            </div>
-          </div>
+          <p className="text-gray-400 text-lg">
+            Challenge writeups from the Safaricom Capture The Flag competition for our team 404FlagNotFound. This was my first CTF competition experience and I learned a lot! We captured 13 flags and we were ranked 49/174 teams.
+          </p>
         </div>
 
         {/* Challenge Writeups */}
         <div className="mb-12">
           <h2 className="text-xl font-semibold text-gray-300 mb-6 flex items-center">
-            <Shield className="w-5 h-5 text-cyan-400 mr-2" />
-            ./challenge_writeups
+            <Terminal className="w-5 h-5 text-cyan-400 mr-2" />
+            ./writeups
           </h2>
 
-          <div className="space-y-6">
+          <div className="space-y-4">
             {/* Real IP Heist Challenge */}
-            <div className="bg-gray-800 border border-gray-700 rounded overflow-hidden">
-              <div className="bg-gray-700 px-6 py-3 border-b border-gray-600">
-                <div className="flex items-center justify-between">
-                  <h3 className="text-lg font-semibold text-cyan-400">
-                    Real IP Heist
-                  </h3>
-                  <div className="flex items-center space-x-4">
-                    <span className="px-2 py-1 bg-gray-600 text-cyan-400 text-xs font-mono rounded">
-                      web-exploitation
-                    </span>
-                    <span className="text-green-400 text-sm font-mono">
-                      50 points
-                    </span>
-                  </div>
+            <div className="bg-gray-800 border border-gray-700 p-6 rounded hover:border-cyan-500 transition-colors">
+              <div className="flex items-center justify-between mb-3">
+                <h3 className="text-lg font-semibold text-cyan-400">
+                  Real IP Heist
+                </h3>
+                <div className="flex items-center space-x-3">
+                  <span className="px-2 py-1 bg-gray-700 text-cyan-400 text-xs font-mono">
+                    web-exploitation
+                  </span>
+                  <span className="text-green-400 text-sm font-mono">
+                    50 pts
+                  </span>
                 </div>
               </div>
 
-              <div className="p-6">
-                <p className="text-gray-400 mb-4">
-                  Exploited server-side trust in IP-related headers
-                  (X-Forwarded-For) to bypass admin authentication by spoofing
-                  internal/localhost addresses.
-                </p>
+              <p className="text-gray-400 mb-4 text-sm">
+                Bypassed admin authentication by spoofing X-Forwarded-For
+                headers to appear as localhost requests.
+              </p>
 
-                <div className="bg-gray-900 border border-gray-600 p-4 rounded mb-4">
-                  <div className="text-green-400 text-sm mb-2">
-                    $ cat target_info.txt
-                  </div>
-                  <div className="text-gray-300 text-sm font-mono">
-                    Target: http://54.72.82.22:8085/
-                    <br />
-                    Flag: safctf{"{c0f1ec1fccb2de4a03031037251f21}"}
-                  </div>
-                </div>
-
-                <div className="space-y-3">
-                  <div className="flex items-center text-sm">
-                    <span className="text-gray-400 w-20">Tools:</span>
-                    <span className="text-gray-300">
-                      curl, basic HTTP header manipulation
-                    </span>
-                  </div>
-                  <div className="flex items-center text-sm">
-                    <span className="text-gray-400 w-20">Method:</span>
-                    <span className="text-gray-300">
-                      IP header spoofing, admin panel access
-                    </span>
-                  </div>
-                  <div className="flex items-center text-sm">
-                    <span className="text-gray-400 w-20">Status:</span>
-                    <span className="text-green-400">✓ SOLVED</span>
-                  </div>
-                </div>
-
+              <div className="flex items-center justify-between">
+                <span className="text-xs text-gray-500">
+                  Flag:{" "}
+                  <code className="text-yellow-400">
+                    safctf{"{c0f1ec1fccb2de4a03031037251f21}"}
+                  </code>
+                </span>
                 <button
                   onClick={() => navigate("/ctf/safaricom-2025/real-ip-heist")}
-                  className="mt-4 inline-flex items-center px-4 py-2 bg-cyan-600 hover:bg-cyan-700 text-white text-sm font-mono rounded transition-colors"
+                  className="inline-flex items-center px-3 py-1 bg-cyan-600 hover:bg-cyan-700 text-white text-xs font-mono rounded transition-colors"
                 >
-                  <ExternalLink className="w-4 h-4 mr-2" />
-                  View Full Writeup
+                  Read More →
                 </button>
               </div>
             </div>
 
             {/* Second Challenge Placeholder */}
-            <div className="bg-gray-800 border border-gray-700 rounded overflow-hidden">
-              <div className="bg-gray-700 px-6 py-3 border-b border-gray-600">
-                <div className="flex items-center justify-between">
-                  <h3 className="text-lg font-semibold text-cyan-400">
-                    Challenge #2
-                  </h3>
-                  <div className="flex items-center space-x-4">
-                    <span className="px-2 py-1 bg-gray-600 text-purple-400 text-xs font-mono rounded">
-                      category-tbd
-                    </span>
-                    <span className="text-green-400 text-sm font-mono">
-                      XX points
-                    </span>
-                  </div>
-                </div>
+            <div className="bg-gray-800 border border-gray-700 p-6 rounded border-dashed opacity-60">
+              <div className="flex items-center justify-between mb-3">
+                <h3 className="text-lg font-semibold text-gray-500">
+                  Challenge #2
+                </h3>
+                <span className="text-gray-500 text-sm font-mono">
+                  Coming soon
+                </span>
               </div>
 
-              <div className="p-6">
-                <p className="text-gray-400 mb-4">
-                  Details of your second challenge writeup will be added here...
-                </p>
-
-                <div className="bg-gray-900 border border-gray-600 p-4 rounded mb-4">
-                  <div className="text-green-400 text-sm mb-2">
-                    $ cat challenge2_info.txt
-                  </div>
-                  <div className="text-gray-300 text-sm font-mono">
-                    Target: TBD
-                    <br />
-                    Flag: TBD
-                  </div>
-                </div>
-
-                <div className="space-y-3">
-                  <div className="flex items-center text-sm">
-                    <span className="text-gray-400 w-20">Tools:</span>
-                    <span className="text-gray-300">TBD</span>
-                  </div>
-                  <div className="flex items-center text-sm">
-                    <span className="text-gray-400 w-20">Method:</span>
-                    <span className="text-gray-300">TBD</span>
-                  </div>
-                  <div className="flex items-center text-sm">
-                    <span className="text-gray-400 w-20">Status:</span>
-                    <span className="text-green-400">✓ SOLVED</span>
-                  </div>
-                </div>
-
-                <button className="mt-4 inline-flex items-center px-4 py-2 bg-cyan-600 hover:bg-cyan-700 text-white text-sm font-mono rounded transition-colors">
-                  <ExternalLink className="w-4 h-4 mr-2" />
-                  View Full Writeup
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {/* Terminal Output Section */}
-        <div className="mb-12">
-          <h2 className="text-xl font-semibold text-gray-300 mb-4 flex items-center">
-            <Terminal className="w-5 h-5 text-green-400 mr-2" />
-            ./terminal_session
-          </h2>
-          <div className="bg-black border border-gray-600 p-4 rounded font-mono text-sm overflow-x-auto">
-            <div className="text-green-400">
-              root@securecloudx:~/ctf/safaricom2025#
-            </div>
-            <div className="text-gray-300 mt-2">
-              <span className="text-cyan-400">$</span> ls -la writeups/
-              <br />
-              total 2<br />
-              -rw-r--r-- 1 hacker hacker 4096 Oct 6 23:32 real-ip-heist.md
-              <br />
-              -rw-r--r-- 1 hacker hacker 3847 Oct 6 23:45 challenge2.md
-              <br />
-              <br />
-              <span className="text-cyan-400">$</span> wc -l writeups/*.md
-              <br />
-              <span className="text-yellow-400"> 127</span>{" "}
-              writeups/real-ip-heist.md
-              <br />
-              <span className="text-yellow-400"> 98</span>{" "}
-              writeups/challenge2.md
-              <br />
-              <span className="text-yellow-400"> 225</span> total
-              <br />
-              <br />
-              <span className="text-cyan-400">$</span> echo "CTF session
-              complete!"
-              <br />
-              <span className="text-green-400">CTF session complete!</span>
+              <p className="text-gray-600 text-sm">
+                Second writeup will be added here...
+              </p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
This pull request introduces a new section for CTF (Capture The Flag) writeups to the application, focusing on the Safaricom CTF 2025 event. It adds new pages and routes to showcase competition details and individual challenge writeups, and updates the `GetStartedPage` to feature CTF content. These changes improve the site's structure for cybersecurity challenge documentation and make it easier for users to discover and navigate writeups.

### New CTF Writeups Feature

* Added a dedicated CTF writeups section to `GetStartedPage`, including a featured card for Safaricom CTF 2025 and a placeholder for future competitions. This section highlights available writeups and provides navigation to the new content.

### Routing and Navigation Updates

* Registered new routes in `App.jsx` for `/ctf/safaricom-2025` and `/ctf/safaricom-2025/real-ip-heist`, enabling direct access to the Safaricom CTF 2025 event page and the Real IP Heist challenge writeup. [[1]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R44-R45) [[2]](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661R60-R64)

### New Pages for CTF Content

* Created `SafaricomCTF2025.jsx`, a new page detailing the Safaricom CTF 2025 event, including team achievements, a summary of challenges, and links to individual writeups. The page features a terminal-inspired design and navigation controls.

---

These changes collectively enhance the site's support for cybersecurity competition documentation and improve user navigation for CTF-related content.