### PR TITLE
Fix cert share

### DIFF
--- a/public/blog/blog-manifest.json
+++ b/public/blog/blog-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-19T07:28:31.190Z",
+  "generatedAt": "2026-04-19T08:27:48.015Z",
   "posts": [
     {
       "filename": "monitor-compliance.md",

--- a/src/components/Certificate.jsx
+++ b/src/components/Certificate.jsx
@@ -224,15 +224,6 @@ export default function Certificate({ userName, userId, completedDate }) {
           )}
         </button>
         {verifyUrl && (
-          <button
-            onClick={() => { navigator.clipboard.writeText(verifyUrl); }}
-            className="flex items-center gap-2 border border-gray-600 hover:border-gray-400 text-gray-400 hover:text-gray-200 font-mono text-sm px-6 py-2.5 transition-colors"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
-            Copy Verify Link
-          </button>
-        )}
-        {verifyUrl && (
           <a
             href={`https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME&name=${encodeURIComponent('Cloud Security Engineering')}&organizationName=${encodeURIComponent('securecloudX')}&issueYear=${issueDate.getFullYear()}&issueMonth=${issueDate.getMonth() + 1}&certUrl=${encodeURIComponent(verifyUrl)}&certId=${encodeURIComponent(certId)}`}
             target="_blank"
@@ -252,17 +243,6 @@ export default function Certificate({ userName, userId, completedDate }) {
           >
             <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
             Share on LinkedIn
-          </a>
-        )}
-        {shareUrl && (
-          <a
-            href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(`I just completed all 8 phases of the @securecloudX Cloud Security Engineering Program! \u{1F6E1}\n\nVerify my certificate:`)}&url=${encodeURIComponent(shareUrl)}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-2 border border-gray-600 hover:border-gray-400 text-gray-400 hover:text-gray-200 font-mono text-sm px-6 py-2.5 transition-colors"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
-            Share on X
           </a>
         )}
       </div>

--- a/src/pages/CertificatePage.jsx
+++ b/src/pages/CertificatePage.jsx
@@ -5,6 +5,7 @@ import { useProgress } from "../hooks/useProgress";
 import Certificate from "../components/Certificate";
 
 const PHASE_IDS = [1, 2, 3, 4, 5, 6, 7, 8];
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
 
 export default function CertificatePage() {
   const { user, loading: authLoading } = useAuth();
@@ -99,6 +100,9 @@ export default function CertificatePage() {
         </div>
 
         {/* Social CTA */}
+        {(() => {
+          const certShareBase = `${SUPABASE_URL}/functions/v1/cert-share`;
+          return (
         <div className="mt-12 max-w-lg mx-auto text-center bg-gray-800 border border-gray-700 p-6">
           <p className="text-gray-300 text-sm mb-1">You earned it — now let the world know.</p>
           <p className="text-gray-500 text-xs leading-relaxed mb-5">
@@ -108,13 +112,13 @@ export default function CertificatePage() {
 
           <div className="flex flex-wrap items-center justify-center gap-3 mb-5">
             <a
-              href="https://twitter.com/intent/tweet?text=I%20just%20completed%20the%20Cloud%20Security%20Engineering%20Program%20on%20%40securecloudX%20%F0%9F%9B%A1%EF%B8%8F%20Check%20it%20out%3A%20https%3A%2F%2Fsecureclouds.pages.dev"
+              href={`https://twitter.com/intent/tweet?text=${encodeURIComponent('I just completed all 8 phases of the @securecloudX Cloud Security Engineering Program! \u{1F6E1}\n\nVerify my certificate:')}&url=${encodeURIComponent(certShareBase + '?certId=SCX')}`}
               target="_blank"
               rel="noopener noreferrer"
               className="flex items-center gap-2 border border-gray-600 hover:border-gray-400 text-gray-400 hover:text-gray-200 font-mono text-xs px-4 py-2 transition-colors"
             >
               <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
-              Post on X
+              Share on X
             </a>
             <a
               href="https://github.com/0tieno/securecloudX"
@@ -131,6 +135,8 @@ export default function CertificatePage() {
             tag <span className="text-gray-400">@securecloudX</span> on X · <span className="text-gray-400">@ronney otieno</span> on LinkedIn · we love seeing your wins
           </p>
         </div>
+          );
+        })()}
       </div>
     </div>
   );


### PR DESCRIPTION
This pull request updates the way certificate sharing and social media CTAs are handled, focusing on centralizing and improving the sharing experience. Key changes include removing redundant share buttons from the certificate component, introducing a centralized and dynamic social sharing section on the certificate page, and ensuring sharing URLs use environment variables for flexibility.

**Certificate sharing and social CTA improvements:**

* Removed the "Copy Verify Link" and "Share on X" buttons from the `Certificate` component to avoid duplicate sharing options and streamline the UI (`src/components/Certificate.jsx`). [[1]](diffhunk://#diff-dc3ea7ec988e4903f27dac7170a322287ec51ec39420aa1684ad3761929cce94L226-L234) [[2]](diffhunk://#diff-dc3ea7ec988e4903f27dac7170a322287ec51ec39420aa1684ad3761929cce94L257-L267)
* Added a new, centralized social CTA section on the `CertificatePage` that dynamically constructs the certificate share URL using the `SUPABASE_URL` environment variable, ensuring correct and configurable links (`src/pages/CertificatePage.jsx`). [[1]](diffhunk://#diff-731a0c978936aa7108767ad9d1103391beebb366b5180a975c997a73564c24e0R8) [[2]](diffhunk://#diff-731a0c978936aa7108767ad9d1103391beebb366b5180a975c997a73564c24e0R103-R105)
* Updated the "Share on X" button in the new CTA section to use a more descriptive message and the dynamic certificate share URL, replacing the previous hardcoded URL and message (`src/pages/CertificatePage.jsx`).
* Adjusted the layout and messaging of the social CTA section for better clarity and user engagement (`src/pages/CertificatePage.jsx`).

**Other:**

* Updated the blog manifest's `generatedAt` timestamp (no functional impact) (`public/blog/blog-manifest.json`).